### PR TITLE
Added LottieReactNative support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -548,7 +548,9 @@
       "react-native-version-number@0.3.4",
       "appcenter-analytics@1.11.0",
       "appcenter@1.11.0",
-      "appcenter-crashes@1.11.0"
+      "appcenter-crashes@1.11.0",
+      "lottie-ios@2.5.0",
+      "lottie-react-native@2.5.11"
     ],
     "targetJsDependencies": ["react@16.6.3"]
   },
@@ -584,7 +586,9 @@
       "react-native-version-number@0.3.4",
       "appcenter-analytics@1.11.0",
       "appcenter@1.11.0",
-      "appcenter-crashes@1.11.0"
+      "appcenter-crashes@1.11.0",
+      "lottie-ios@2.5.0",
+      "lottie-react-native@2.5.11"
     ],
     "targetJsDependencies": ["react@16.6.3"]
   },
@@ -620,7 +624,9 @@
       "react-native-version-number@0.3.4",
       "appcenter-analytics@1.11.0",
       "appcenter@1.11.0",
-      "appcenter-crashes@1.11.0"
+      "appcenter-crashes@1.11.0",
+      "lottie-ios@2.5.0",
+      "lottie-react-native@2.5.11"
     ],
     "targetJsDependencies": ["react@16.6.3"]
   }

--- a/plugins/ern_v0.28.0+/lottie-ios_v2.5.0+/config.json
+++ b/plugins/ern_v0.28.0+/lottie-ios_v2.5.0+/config.json
@@ -1,0 +1,33 @@
+{
+  "ios": {
+    "copy": [
+      {
+        "source": "./lottie-ios",
+        "dest": "{{{projectName}}}/Libraries/Lottie"
+      },
+      {
+        "source": "./Lottie.xcodeproj",
+        "dest": "{{{projectName}}}/Libraries/Lottie"
+      },
+      {
+        "source": "./Lottie",
+        "dest": "{{{projectName}}}/Libraries/Lottie"
+      }
+    ],
+    "pbxproj": {
+      "addProject": [
+        {
+          "addAsTargetDependency": true,
+          "path": "Lottie/Lottie.xcodeproj",
+          "group": "Libraries",
+          "frameworks": [
+            {
+              "name": "Lottie.framework",
+              "target": "Lottie_iOS"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/plugins/ern_v0.28.0+/lottie-react-native_v2.5.11+/LottieReactNativePlugin.java
+++ b/plugins/ern_v0.28.0+/lottie-react-native_v2.5.11+/LottieReactNativePlugin.java
@@ -1,0 +1,17 @@
+
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.airbnb.android.react.lottie.LottiePackage;
+
+public class LottieReactNativePlugin implements ReactPlugin {
+
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new LottiePackage();
+    }
+}

--- a/plugins/ern_v0.28.0+/lottie-react-native_v2.5.11+/config.json
+++ b/plugins/ern_v0.28.0+/lottie-react-native_v2.5.11+/config.json
@@ -2,7 +2,7 @@
   "android": {
     "root": "src",
     "moduleName": "android",
-    "dependencies": ["com.airbnb.android:lottie:2.6.0"]
+    "dependencies": ["com.airbnb.android:lottie:2.5.6"]
   },
   "ios": {
     "copy": [

--- a/plugins/ern_v0.28.0+/lottie-react-native_v2.5.11+/config.json
+++ b/plugins/ern_v0.28.0+/lottie-react-native_v2.5.11+/config.json
@@ -1,0 +1,29 @@
+{
+  "android": {
+    "root": "src",
+    "moduleName": "android",
+    "dependencies": ["com.airbnb.android:lottie:2.6.0"]
+  },
+  "ios": {
+    "copy": [
+      {
+        "source": "./src/ios/*",
+        "dest": "{{{projectName}}}/Libraries/LottieReactNative"
+      }
+    ],
+    "pbxproj": {
+      "addProject": [
+        {
+          "path": "LottieReactNative/LottieReactNative.xcodeproj",
+          "group": "Libraries",
+          "staticLibs": [
+            {
+              "name": "libLottieReactNative.a",
+              "target": "LottieReactNative"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Added support for `lottie-react-native`.

Though,`lottie-react-native` is not as simple to add as the previous projects for several reasons:
1. For iOs, we need to also pull in `lottie-ios`, the way to do it with regular react-native is to add both and link both, so I followed the same process here and added the `lottie-ios` project to the manifest.
2. For iOs, `lottie-react-native` expects to have the `Lottie.framework` available. AFAIU it is complicated to embed a framework into another framework (so the `ElectrodeContainer.framework`) and it is not recommended to do so anyways. So in order to actually use `Lottie` in your app, you still need to embed the `Lottie.framework` in your ErnRunner project.

I think those are "limitations" that make sense and are logical, though when one is installing `lottie-react-native` in a `react-native` project, you are made aware of those by the `lottie-react-native` github repository documentation.
In case of `electrode-native`, the user doesn't really have any documentation.
I would propose to add the support in `electrode-native-manifest` for documentation file, maybe in a similar way they exist at the `electrode-native` repo to support explanations for plugins which are a bit harder to install then `ern add X`.

Happy to help with that proposal if that makes sense.