### PR TITLE
Adds compatibility for lottie-react-native 3.5.0+

### DIFF
--- a/plugins/ern_v0.14.0+/lottie-react-native_v3.5.0+/LottieReactNativePlugin.java
+++ b/plugins/ern_v0.14.0+/lottie-react-native_v3.5.0+/LottieReactNativePlugin.java
@@ -1,0 +1,15 @@
+package com.walmartlabs.ern.container.plugins;
+
+import android.app.Application;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.facebook.react.ReactInstanceManagerBuilder;
+import com.facebook.react.ReactPackage;
+import com.airbnb.android.react.lottie.LottiePackage;
+
+public class LottieReactNativePlugin implements ReactPlugin {
+    public ReactPackage hook(@NonNull Application application, @Nullable ReactPluginConfig config) {
+        return new LottiePackage();
+    }
+}

--- a/plugins/ern_v0.14.0+/lottie-react-native_v3.5.0+/config.json
+++ b/plugins/ern_v0.14.0+/lottie-react-native_v3.5.0+/config.json
@@ -1,0 +1,29 @@
+{
+  "android": {
+    "root": "src",
+    "moduleName": "android",
+    "dependencies": ["com.airbnb.android:lottie:3.4.0"]
+  },
+  "ios": {
+    "copy": [
+      {
+        "source": "./src/ios/*",
+        "dest": "{{{projectName}}}/Libraries/LottieReactNative"
+      }
+    ],
+    "pbxproj": {
+      "addProject": [
+        {
+          "path": "LottieReactNative/LottieReactNative.xcodeproj",
+          "group": "Libraries",
+          "staticLibs": [
+            {
+              "name": "libLottieReactNative.a",
+              "target": "LottieReactNative"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The newer version of `lottie-react-native` [here](https://github.com/lottie-react-native/lottie-react-native/blob/v3.5.0/src/android/build.gradle#L34) requires a newer version of `lottie-android`, so created a config for that. ✨ 